### PR TITLE
Fix broken footer link in v1.0 HTML version

### DIFF
--- a/version/1/0/index.htm
+++ b/version/1/0/index.htm
@@ -126,6 +126,6 @@
 
 <h2>License</h2>
 
-<p><span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">Community Covenant</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="http://community-covenant.net/" property="cc:attributionName" rel="cc:attributionURL">Coraline Ada Ehmke</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.<br />Based on a work at <a xmlns:dct="http://purl.org/dc/terms/" href="http://community-covenant.net/latest/" rel="dct:source">http://community-covenant.net/</a>.</p>
+<p><span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">Community Covenant</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="http://community-covenant.net/" property="cc:attributionName" rel="cc:attributionURL">Coraline Ada Ehmke</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.<br />Based on a work at <a xmlns:dct="http://purl.org/dc/terms/" href="http://community-covenant.net/" rel="dct:source">http://community-covenant.net/</a>.</p>
 
 </body>


### PR DESCRIPTION
The HTML version's footer links to http://community-covenant.net/latest/ which is currently not found: I presume this should just be http://community-covenant.net/ like the other versions?